### PR TITLE
Add --warmup option to control physics warmup loops

### DIFF
--- a/SpineViewerCLI/SpineViewerCLI.cs
+++ b/SpineViewerCLI/SpineViewerCLI.cs
@@ -181,16 +181,7 @@ options:
 
             if (warmup)
             {
-                float delta = 1f / fps;
-                for (int i = 0; i < warmUpLoops; i++)
-                {
-                    float t = 0;
-                    while (t < trackEntry.Animation.Duration)
-                    {
-                        sp.Update(delta);
-                        t += delta;
-                    }
-                }
+                sp.Update(trackEntry.Animation.Duration * warmUpLoops);
             }
 
             foreach (var slotName in hideSlots)


### PR DESCRIPTION
Create a new --warmup argument to specify the number of warmup loops for physics before export. This allows users to control how many times the animation is pre-processed to stabilize physics.