### PR TITLE
修复物理预热并支持变速下的无缝循环

### DIFF
--- a/SpineViewerCLI/ExportCommand.cs
+++ b/SpineViewerCLI/ExportCommand.cs
@@ -344,7 +344,9 @@ namespace SpineViewerCLI
 
             // 时间轴处理
             var warmup = result.GetValue(OptWarmUp);
-            spine.Update(warmup < 0 ? spine.GetAnimationMaxDuration() : warmup);
+            if (warmup < 0) warmup = spine.GetAnimationMaxDuration();
+            for (float t = 0, step = 1f / 60f; t < warmup; t += step)
+                spine.Update(Math.Min(step, warmup - t));
             spine.Update(result.GetValue(OptTime));
 
             using var exporter = GetExporterFilledWithArgs(result, spine);
@@ -415,7 +417,8 @@ namespace SpineViewerCLI
             }
 
             var duration = result.GetValue(OptDuration);
-            if (duration < 0) duration = spine.GetAnimationMaxDuration();
+            // 除以速度才能覆盖整数个循环, 否则 speed != 1 时接缝跳变
+            if (duration < 0) duration = spine.GetAnimationMaxDuration() / Math.Max(result.GetValue(OptSpeed), 1e-6f);
 
             if (formatType == 0x01)
             {

--- a/SpineViewerCLI/ExportCommand.cs
+++ b/SpineViewerCLI/ExportCommand.cs
@@ -345,7 +345,9 @@ namespace SpineViewerCLI
             // 时间轴处理
             var warmup = result.GetValue(OptWarmUp);
             if (warmup < 0) warmup = spine.GetAnimationMaxDuration();
-            for (float t = 0, step = 1f / 60f; t < warmup; t += step)
+
+            // 按传入的帧率进行逐帧预热, 不能直接更新整个动画时长, 否则物理效果无法预热
+            for (float t = 0, step = 1f / result.GetValue(OptFps); t < warmup; t += step)
                 spine.Update(Math.Min(step, warmup - t));
             spine.Update(result.GetValue(OptTime));
 
@@ -417,8 +419,10 @@ namespace SpineViewerCLI
             }
 
             var duration = result.GetValue(OptDuration);
+            
             // 除以速度才能覆盖整数个循环, 否则 speed != 1 时接缝跳变
-            if (duration < 0) duration = spine.GetAnimationMaxDuration() / Math.Max(result.GetValue(OptSpeed), 1e-6f);
+            if (duration < 0) 
+                duration = spine.GetAnimationMaxDuration() / Math.Max(result.GetValue(OptSpeed), 1e-6f);
 
             if (formatType == 0x01)
             {


### PR DESCRIPTION
修复两个 CLI 导出问题：物理预热失效，以及变速时无法无缝循环。

### 1. 预热（warm-up）无效
`--warm-up` 之前是一次性跳过整段预热时间来推进动画。物理约束的驱动力来自每帧之间骨骼的位移，所以这样几乎不产生任何驱动力，而当预热时间等于循环时长时，骨骼回到起点，净位移为零。
结果就是：无论传入什么值，物理始终停留在初始静止姿势。

**修复：** 改为每次只推进一小段时间（`1/60` 秒）逐帧推进动画，让物理像正常播放时那样逐步累积驱动力。

### 2. 速度 ≠ 1 时出现接缝
自动时长之前直接用动画原始时长。由于导出覆盖的动画时间为 `时长 × 速度`，任何不等于 1 的 `--speed` 都会得到非整数个循环，从而在循环点留下姿势错位（接缝跳变）。

**修复：** 自动时长除以速度，保证导出始终覆盖整数个循环。